### PR TITLE
fix: make sure elastalert run as pid 1 in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /opt/elastalert/config && \
     mkdir -p /opt/elastalert/rules && \
     echo "#!/bin/sh" >> /opt/elastalert/run.sh && \
     echo "elastalert-create-index --config /opt/config/elastalert_config.yaml" >> /opt/elastalert/run.sh && \
-    echo "elastalert --config /opt/config/elastalert_config.yaml \"\$@\"" >> /opt/elastalert/run.sh && \
+    echo "exec elastalert --config /opt/config/elastalert_config.yaml \"\$@\"" >> /opt/elastalert/run.sh && \
     chmod +x /opt/elastalert/run.sh
 
 VOLUME [ "/opt/config", "/opt/rules" ]


### PR DESCRIPTION
This is a small change in the entrypoint script to make sure elastalert runs as pid 1 and hence it can receive process signals (e.g. to allow a graceful shutdown upon receiving SIGTERM)