### PR TITLE
Install certifi to fix InsecureRequestWarning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --update upgrade && \
     apk add gcc libffi-dev musl-dev python-dev openssl-dev tzdata libmagic && \
     rm -rf /var/cache/apk/*
 
-RUN pip install elastalert==${ELASTALERT_VERSION} && \
+RUN pip install elastalert==${ELASTALERT_VERSION} certifi && \
     apk del gcc libffi-dev musl-dev python-dev openssl-dev
 
 RUN mkdir -p /opt/elastalert/config && \


### PR DESCRIPTION
Install `certifi` pip module to fix `InsecureRequestWarning`:

I've seen multiple events in the log like these:
```
test-elastalert-5b7586dd7d-qrrm9 elastalert   InsecureRequestWarning)
test-elastalert-5b7586dd7d-qrrm9 elastalert /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```

Adding this pip module seems to resolve it.