### PR TITLE
Bump ElastAlert version to latest (0.2.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-alpine
 LABEL description="ElastAlert suitable for Kubernetes and Helm"
 LABEL maintainer="Jason Ertel (jertel at codesim.com)"
 
-ARG ELASTALERT_VERSION=0.2.1
+ARG ELASTALERT_VERSION=0.2.4
 
 RUN apk --update upgrade && \
     apk add gcc libffi-dev musl-dev python-dev openssl-dev tzdata libmagic && \


### PR DESCRIPTION
Hello!

Thank you for this wonderful container.  :)  This PR just bumps the version to the latest version of ElastAlert (`0.2.4`, released 16 April 2020).  It's okay if you don't accept this, I can always maintain my own container.

Thanks again!