### PR TITLE
Fixed naming error in the Docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build . -t elastalert
 A properly configured elastalert_config.json file must be mounted into the container during startup of the container. Use the [example file](https://github.com/Yelp/elastalert/blob/master/config.yaml.example) provided by Elastalert as a template, and once saved locally to a file such as `/tmp/elastalert.json`, run the container as follows:
 
 ```bash
-docker run -d -v /tmp/elastalert.json:/opt/config/elastalert_config.json jertel/elastalert-docker
+docker run -d -v /tmp/elastalert.json:/opt/config/elastalert_config.yaml jertel/elastalert-docker
 ```
 
 ## Kubernetes


### PR DESCRIPTION
Hi,

I couldn't get the Docker image to start properly before I renamed the extension to .yaml for the config file. 

Hope you don't mind a pull request for it.

// Mike