### PR TITLE
add imagePullSecrets option to helm chart

### DIFF
--- a/chart/elastalert/Chart.yaml
+++ b/chart/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 1.8.1
+version: 1.8.2
 appVersion: 0.2.4
 home: https://github.com/Yelp/elastalert
 sources:

--- a/chart/elastalert/README.md
+++ b/chart/elastalert/README.md
@@ -49,6 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.repository`                           | docker image                                                                                                                  | jertel/elastalert-docker        |
 | `image.tag`                                  | docker image tag                                                                                                              | 0.2.4                           |
 | `image.pullPolicy`                           | image pull policy                                                                                                             | IfNotPresent                    |
+| `image.pullSecrets`                          | image pull secrets                                                                                                            | []                              |
 | `podAnnotations`                             | Annotations to be added to pods                                                                                               | {}                              |
 | `command`                                    | command override for container                                                                                                | `NULL`                          |
 | `args`                                       | args override for container                                                                                                   | `NULL`                          |

--- a/chart/elastalert/templates/deployment.yaml
+++ b/chart/elastalert/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
+{{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{- range . }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
       volumes:
         - name: rules
 {{- if .Values.secretRulesName }}

--- a/chart/elastalert/values.yaml
+++ b/chart/elastalert/values.yaml
@@ -29,6 +29,7 @@ image:
   # docker image tag
   tag: 0.2.4
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 resources: {}
 


### PR DESCRIPTION
Adds the option to add imagePullSecrets to the helm chart using `image.pullSecrets` in the `values.yaml` file.

I also bumped the chart version from `1.8.1` to `1.8.2`.