### PR TITLE
add oldQueryLimitMins option to helm chart

### DIFF
--- a/chart/elastalert/Chart.yaml
+++ b/chart/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 1.8.3
+version: 1.8.4
 appVersion: 0.2.4
 home: https://github.com/Yelp/elastalert
 sources:

--- a/chart/elastalert/README.md
+++ b/chart/elastalert/README.md
@@ -85,6 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `realertIntervalMins`                        | Time between alarms for same rule, in minutes                                                                                 | `NULL`                          |
 | `alertRetryLimitMins`                        | Time to retry failed alert deliveries, in minutes                                                                             | 2880 (2 days)                   |
 | `bufferTimeMins`                             | Default rule buffer time, in minutes                                                                                          | 15                              |
+| `oldQueryLimitMins`                          | The maximum time between queries for ElastAlert to start at the most recently run query, in minutes                           | 10080 (1 week)                  |
 | `writebackIndex`                             | Name or prefix of elastalert index(es)                                                                                        | elastalert                      |
 | `nodeSelector`                               | Node selector for deployment                                                                                                  | {}                              |
 | `affinity`                                   | Affinity specifications for the deployed pod(s)                                                                               | {}                              |

--- a/chart/elastalert/templates/config.yaml
+++ b/chart/elastalert/templates/config.yaml
@@ -21,6 +21,8 @@ data:
 {{- end }}
     buffer_time:
       minutes: {{ .Values.bufferTimeMins }}
+    old_query_limit:
+      minutes: {{ .Values.oldQueryLimitMins }}
     es_host: {{ .Values.elasticsearch.host }}
     es_port: {{ .Values.elasticsearch.port }}
 {{- if .Values.elasticsearch.username }}

--- a/chart/elastalert/values.yaml
+++ b/chart/elastalert/values.yaml
@@ -10,6 +10,9 @@ runIntervalMins: 1
 # Default rule buffer duration, in minutes
 bufferTimeMins: 15
 
+#The maximum time between queries for ElastAlert to start at the most recently run query. The default is one week.
+oldQueryLimitMins: 10080
+
 # Amount of time to retry and deliver failed alerts (1440 minutes per day)
 alertRetryLimitMins: 2880
 


### PR DESCRIPTION
Adds the option to set oldQueryLimitMins in the values.yaml file.

I also bumped the chart version from 1.8.3 to 1.8.4.