### PR TITLE
Fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-alpine3.13
 
 LABEL description="ElastAlert suitable for Kubernetes and Helm"
 LABEL maintainer="Jason Ertel (jertel at codesim.com)"
@@ -9,7 +9,9 @@ RUN apk --update upgrade && \
     apk add gcc libffi-dev musl-dev python3-dev openssl-dev tzdata libmagic cargo && \
     rm -rf /var/cache/apk/*
 
-RUN pip install elastalert==${ELASTALERT_VERSION} && \
+RUN pip install --upgrade pip && \
+    pip install cryptography && \
+    pip install elastalert==${ELASTALERT_VERSION} && \
     apk del gcc libffi-dev musl-dev python3-dev openssl-dev cargo
 
 RUN mkdir -p /opt/elastalert && \


### PR DESCRIPTION
- add `pip install --upgrade pip`

```
ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 20.3.3; however, version 21.0.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```
- change `python:3.6-alpine` to `python:3.6-alpine3.13`
- add `pip install cryptography`

alpine: 3.11・・・rust 1.39.0-r0
alpine: 3.12・・・rust 1.44.0-r0
alpine: 3.13・・・rust 1.47.0-r2

alpine: By setting 3.13, I was able to clear the condition of rust >= 1.45, so I found that no error occurred.

```
  error: Rust 1.44.0 does not match extension requirement >=1.45.0
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
```
