### PR TITLE
Add jq and curl to container for use with EA command type alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Jason Ertel (jertel at codesim.com)"
 ARG ELASTALERT_VERSION=0.2.4
 
 RUN apk --update upgrade && \
-    apk add gcc libffi-dev musl-dev python3-dev openssl-dev tzdata libmagic cargo && \
+    apk add gcc libffi-dev musl-dev python3-dev openssl-dev tzdata libmagic cargo jq curl && \
     rm -rf /var/cache/apk/*
 
 RUN pip install elastalert==${ELASTALERT_VERSION} && \


### PR DESCRIPTION
Couple of very useful apps for use with Elasticsearch and Elastalert `command` type alerts.  With jq we can munge the output of `pipe_match_json` of the `command` alert as an example.