### PR TITLE
Parametrize rules_folder and scan_subdirectories

### DIFF
--- a/chart/elastalert/Chart.yaml
+++ b/chart/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 1.8.5
+version: 1.9.0
 appVersion: 0.2.4
 home: https://github.com/Yelp/elastalert
 sources:

--- a/chart/elastalert/templates/config.yaml
+++ b/chart/elastalert/templates/config.yaml
@@ -11,8 +11,8 @@ metadata:
 data:
   elastalert_config: |-
     ---
-    rules_folder: /opt/rules
-    scan_subdirectories: false
+    rules_folder: {{ .Values.rulesFolder | default "/opt/rules" }}
+    scan_subdirectories: {{ .Values.scanSubdirectories | default false }}
     run_every:
       minutes: {{ .Values.runIntervalMins }}
 {{- if .Values.realertIntervalMins }}

--- a/chart/elastalert/values.yaml
+++ b/chart/elastalert/values.yaml
@@ -4,6 +4,12 @@ replicaCount: 1
 # number of helm release revisions to retain
 revisionHistoryLimit: 5
 
+# rules folder
+rulesFolder: /opt/rules
+
+# scan rules folder subdirectories
+scanSubdirectories: false
+
 # Default internal between alert checks against the elasticsearch datasource, in minutes
 runIntervalMins: 1
 

--- a/chart/elastalert/values.yaml
+++ b/chart/elastalert/values.yaml
@@ -4,11 +4,13 @@ replicaCount: 1
 # number of helm release revisions to retain
 revisionHistoryLimit: 5
 
-# rules folder
-rulesFolder: /opt/rules
+# optional rules folder override, for use with custom images with baked in rules
+# since secretRulesName option uses /opt/rules as a mount path, you can't use this path for your custom baked in rules
+# you should specify a different folder like: /opt/custom_rules
+# rulesFolder: /opt/custom_rules
 
-# scan rules folder subdirectories
-scanSubdirectories: false
+# optional, scan rules folder subdirectories
+# scanSubdirectories: false
 
 # Default internal between alert checks against the elasticsearch datasource, in minutes
 runIntervalMins: 1


### PR DESCRIPTION
In config.yaml all but two parameters are parametrized.
I would like to parametrize rules_folder and scan_subdirectories so that they can be specified conveniently without a need to create a separate elastalert-config-secret. 